### PR TITLE
[expression_eval] fix undefined IsConsole crash

### DIFF
--- a/scripts/consolepp/expression_eval.lua
+++ b/scripts/consolepp/expression_eval.lua
@@ -28,7 +28,7 @@ function ConsoleScreen:Run()
 		G.ConsoleScreenSettings:AddLastExecutedCommand(fnstr, self.toggle_remote_execute)
 	end
 
-	if self.toggle_remote_execute and TheNet:GetIsClient() and (TheNet:GetIsServerAdmin() or IsConsole()) then
+	if self.toggle_remote_execute and TheNet:GetIsClient() and (TheNet:GetIsServerAdmin() or G.IsConsole()) then
         local x, y, z = TheSim:ProjectScreenPos(TheSim:GetPosition())
         --- [NEW] ---
         if fnstr:byte() == string.byte("=") then


### PR DESCRIPTION
Very simple patch, just a missing global index.

If you're curious, here's the relevant crash output. It only gets triggered when you're not an admin, so it may have slipped through testing.
```
[00:02:03]: [string "../mods/workshop-2758553790/scripts/console..."]:31: attempt to call global 'IsConsole' (a nil value)
LUA ERROR stack traceback:
    ../mods/workshop-2758553790/scripts/consolepp/expression_eval.lua:31 in () ? (Lua) <22-42>
    =(tail call):-1 in ()  (tail) <-1--1>
    =(tail call):-1 in ()  (tail) <-1--1>
    scripts/screens/consolescreen.lua:186 in (field) fn (Lua) <184-193>
    scripts/scheduler.lua:186 in (method) OnTick (Lua) <164-216>
    scripts/scheduler.lua:419 in (global) RunStaticScheduler (Lua) <417-425>
    scripts/update.lua:178 in () ? (Lua) <169-220>
```